### PR TITLE
fix: update MCP protocol version to 2025-11-25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnifocus-claude-extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Enhanced OmniFocus GTD integration for Claude Desktop with advanced features",
   "main": "build.js",
   "scripts": {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -630,7 +630,7 @@ async function handleRequest(request) {
                 initialized = true;
                 
                 const initResult = {
-                    protocolVersion: '2024-11-05',
+                    protocolVersion: '2025-11-25',
                     capabilities: {
                         tools: {
                             listChanged: true


### PR DESCRIPTION
## Summary
- Updates MCP protocol version from `2024-11-05` to `2025-11-25` to fix connection failure with current Claude Desktop
- Bumps version to 2.0.2

## Test plan
- [x] Verified extension loads successfully in Claude Desktop after the fix (confirmed via MCP server log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)