### PR TITLE
feat: migrate extension format from DXT to MCPB

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ Triggers on:
 
 Jobs:
 1. **Test**: Runs Jest unit tests with coverage
-2. **Build**: Creates DXT extension package
+2. **Build**: Creates MCPB extension package
 3. **Release**: Creates GitHub release for version tags
 
 ### Test Suite (`test.yml`)
@@ -73,7 +73,7 @@ No additional secrets required. Uses default GITHUB_TOKEN for releases.
 
 Each workflow run produces:
 - **Test Results**: JSON test output and coverage reports
-- **Build Artifacts**: DXT extension file
+- **Build Artifacts**: MCPB extension file
 - **Build Report**: JSON build metadata
 
 ## Status Badges

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: omnifocus-gtd-dxt
-        path: dist/omnifocus-gtd.dxt
+        name: omnifocus-gtd-mcpb
+        path: dist/omnifocus-gtd.mcpb
         retention-days: 30
     
     - name: Upload build report
@@ -104,7 +104,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          dist/omnifocus-gtd.dxt
+          dist/omnifocus-gtd.mcpb
           dist/build-report.json
         generate_release_notes: true
         draft: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     
     - name: Check JavaScript syntax
       run: |
-        for file in src/**/*.js build.js validate-dxt.js; do
+        for file in src/**/*.js build.js validate-mcpb.js; do
           if [ -f "$file" ]; then
             node -c "$file" || exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Test manifest generation
       run: node test-manifests.js
     
-    - name: Validate DXT build
+    - name: Validate MCPB build
       run: |
         npm run build
         npm run validate

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ yarn.lock
 
 # Built extension files
 *.dxt
+*.mcpb
 
 # Temporary files
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 1. **Backup your OmniFocus database** before upgrading
 2. Uninstall the old extension from Claude Desktop
-3. Download and install `omnifocus-gtd-enhanced.mcpb` (or `.dxt` for versions before 2.0.3)
+3. Download and install `omnifocus-gtd.mcpb` (or `omnifocus-gtd.dxt` for versions before 2.0.3)
 4. All previous commands remain compatible
 5. New features are immediately available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 1. **Backup your OmniFocus database** before upgrading
 2. Uninstall the old extension from Claude Desktop
-3. Download and install `omnifocus-gtd-enhanced.dxt`
+3. Download and install `omnifocus-gtd-enhanced.mcpb` (or `.dxt` for versions before 2.0.3)
 4. All previous commands remain compatible
 5. New features are immediately available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the OmniFocus Claude Extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-03-21
+
+### Changed
+- Renamed extension format from `.dxt` to `.mcpb` to match Anthropic's updated naming
+- Renamed `validate-dxt.js` to `validate-mcpb.js`
+- Updated npm script `build:dxt` to `build:mcpb`
+- Updated CI/CD pipeline artifact names
+- No changes to internal archive format (still ZIP with manifest.json)
+
 ## [2.0.0] - 2024-12-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This is an OmniFocus Claude Desktop Extension that enables advanced task managem
 # Install dependencies
 npm install
 
-# Build the DXT extension file
+# Build the MCPB extension file
 npm run build
 
 # Validate the built extension
@@ -37,7 +37,7 @@ npm test
 # Test specific components
 node test-server.js      # Test MCP server
 node test-manifests.js   # Test manifest generation
-node validate-dxt.js     # Validate DXT package
+node validate-mcpb.js    # Validate MCPB package
 ```
 
 ## Architecture
@@ -54,8 +54,8 @@ node validate-dxt.js     # Validate DXT package
    - Original scripts: `add_task.applescript`, `complete_task.applescript`, `list_inbox.applescript`, `today_tasks.applescript`, `weekly_review.applescript`
    - Enhanced scripts in `enhanced/`: `search_tasks.applescript`, `edit_task.applescript`, `batch_add_tasks.applescript`, `create_recurring_task.applescript`, plus list views
 
-3. **Build System** (`build.js`, `build-dxt-new.js`)
-   - Creates DXT package following official specification
+3. **Build System** (`build.js`)
+   - Creates MCPB package following official specification
    - Handles manifest generation with proper MCPB format (manifest_version: "0.3")
    - Archives extension with correct structure
    - Generates checksums and build reports
@@ -77,7 +77,7 @@ node validate-dxt.js     # Validate DXT package
 1. **AppleScript Escaping**: Always properly escape special characters in AppleScript strings
 2. **OmniFocus Permissions**: Extension requires automation permissions for OmniFocus
 3. **Manifest Format**: Must use MCPB v0.3 format - `manifest_version: "0.3"` with `name` as machine-readable identifier
-4. **Build Output**: Extension files go to `dist/` directory as `.dxt` files
+4. **Build Output**: Extension files go to `dist/` directory as `.mcpb` files
 5. **Error Messages**: Provide clear, actionable error messages from AppleScripts
 6. **Task Matching**: Be careful with task name matching - handle multiple matches gracefully
 
@@ -94,7 +94,7 @@ node validate-dxt.js     # Validate DXT package
 1. Check Claude Desktop logs: `~/Library/Logs/Claude/`
 2. Test AppleScript directly: `osascript src/scripts/[script_name].applescript`
 3. Verify MCP server: `node src/server/index.js` (send test JSON-RPC)
-4. Validate DXT package: `npm run validate`
+4. Validate MCPB package: `npm run validate`
 
 ### Testing AppleScript Changes
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,14 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 1. **Test your changes** with OmniFocus and Claude Desktop
 2. **Update the README** if you've added new commands or changed existing ones
-3. **Update the version number** in omnifocus-gtd.dxt and package.json if appropriate
+3. **Update the version number** in package.json if appropriate
 4. **Write clear commit messages** that explain what changed and why
 
 ## Adding New Commands
 
 When adding a new command to the extension:
 
-1. Add the command definition to the `tools` array in `omnifocus-gtd.dxt`
+1. Add the command definition to the `tools` array in `src/server/index.js`
 2. Ensure the AppleScript is properly formatted and escaped
 3. Test the command thoroughly with various inputs
 4. Add documentation to the README.md

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ A powerful OmniFocus integration for Claude Desktop that enables advanced task m
 
 ### Quick Install
 
-1. Download the latest `omnifocus-gtd.dxt` from the [Releases](https://github.com/geoffdavis/omnifocus-claude-extension/releases) page
+1. Download the latest `omnifocus-gtd.mcpb` from the [Releases](https://github.com/geoffdavis/omnifocus-claude-extension/releases) page
 2. Open Claude Desktop
 3. Navigate to Extensions settings
-4. Drag and drop the `.dxt` file onto the Claude Desktop window
+4. Drag and drop the `.mcpb` file onto the Claude Desktop window
 5. Restart Claude Desktop
 6. The first time you use an OmniFocus tool, macOS will prompt you to grant `node` permission to control OmniFocus - click **Allow**
 
@@ -54,7 +54,7 @@ npm install
 # Build the extension
 npm run build
 
-# The extension will be created at dist/omnifocus-gtd.dxt
+# The extension will be created at dist/omnifocus-gtd.mcpb
 ```
 
 ## Usage Examples
@@ -133,14 +133,14 @@ omnifocus-claude-extension/
 │   └── manifest-template.json      # MCPB v0.3 manifest template
 ├── build.js                        # Build script
 ├── dist/
-│   └── omnifocus-gtd.dxt           # Built extension
+│   └── omnifocus-gtd.mcpb           # Built extension
 └── tests/
 ```
 
 ### Building
 
 ```bash
-# Build the DXT extension
+# Build the MCPB extension
 npm run build
 
 # Clean and rebuild

--- a/build.js
+++ b/build.js
@@ -2,7 +2,7 @@
 
 /**
  * Build Script for OmniFocus Claude Extension
- * Creates a DXT package following the official specification
+ * Creates an MCPB package following the official specification
  */
 
 const fs = require('fs');
@@ -45,7 +45,7 @@ const log = {
 // Configuration
 const BUILD_DIR = path.join(__dirname, 'extension-build');
 const DIST_DIR = path.join(__dirname, 'dist');
-const OUTPUT_FILE = path.join(DIST_DIR, 'omnifocus-gtd.dxt');
+const OUTPUT_FILE = path.join(DIST_DIR, 'omnifocus-gtd.mcpb');
 
 // MCPB manifest format (v0.3 spec)
 const MANIFEST = {
@@ -151,9 +151,9 @@ function createManifest() {
     console.log(JSON.stringify(MANIFEST, null, 2));
 }
 
-// Create the DXT archive
+// Create the MCPB archive
 async function createArchive() {
-    log.blue('📦 Creating DXT archive...');
+    log.blue('📦 Creating MCPB archive...');
     
     return new Promise((resolve, reject) => {
         const output = fs.createWriteStream(OUTPUT_FILE);
@@ -269,7 +269,7 @@ async function build() {
             `${report.scripts.total} total (${report.scripts.original} original + ${report.scripts.enhanced} enhanced)` + 
             colors.reset);
         log.white('📏 Size: ' + colors.cyan + `${(fileSize / 1024).toFixed(2)} KB` + colors.reset);
-        log.gray('\nInstall by dragging the .dxt file to Claude Desktop');
+        log.gray('\nInstall by dragging the .mcpb file to Claude Desktop');
         
     } catch (error) {
         log.bold.red('\n❌ Build failed!\n');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,9 +1013,10 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1034,13 +1035,13 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3282,9 +3283,10 @@
       }
     },
     "node_modules/jest-config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3303,13 +3305,13 @@
       }
     },
     "node_modules/jest-config/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3836,9 +3838,10 @@
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3857,13 +3860,13 @@
       }
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4173,9 +4176,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4296,9 +4299,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4383,9 +4386,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5124,9 +5127,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "node build.js",
     "build:mcpb": "node build.js",
+    "build:dxt": "npm run build:mcpb",
     "clean": "rm -rf dist build build-temp* extension-build",
     "rebuild": "npm run clean && npm run build",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "omnifocus-claude-extension",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Enhanced OmniFocus GTD integration for Claude Desktop with advanced features",
   "main": "build.js",
   "scripts": {
     "build": "node build.js",
-    "build:dxt": "node build.js",
+    "build:mcpb": "node build.js",
     "clean": "rm -rf dist build build-temp* extension-build",
     "rebuild": "npm run clean && npm run build",
     "test": "jest",
@@ -13,7 +13,7 @@
     "test:coverage": "jest --coverage",
     "test:ci": "jest --config jest.config.ci.js --ci",
     "test:legacy": "node test.js",
-    "validate": "node validate-dxt.js",
+    "validate": "node validate-mcpb.js",
     "dev": "npm run build && npm run validate",
     "release": "npm run clean && npm run build && npm run validate"
   },

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,7 +20,7 @@ try {
         VERSION = packageJson.version;
     }
 } catch (error) {
-    // Use fallback version if package.json not found (e.g., when running from DXT)
+    // Use fallback version if package.json not found (e.g., when running from MCPB package)
 }
 
 // Initialize stdio interface

--- a/test-manifests.js
+++ b/test-manifests.js
@@ -7,7 +7,7 @@ const archiver = require('archiver');
 async function buildMinimal() {
     const configs = [
         {
-            name: 'test1-node-basic.dxt',
+            name: 'test1-node-basic.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test1",
@@ -19,7 +19,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test2-node-command.dxt',
+            name: 'test2-node-command.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test2",
@@ -32,7 +32,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test3-node-command-args.dxt',
+            name: 'test3-node-command-args.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test3",
@@ -46,7 +46,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test4-python-basic.dxt',
+            name: 'test4-python-basic.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test4",
@@ -58,7 +58,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test5-python-command.dxt',
+            name: 'test5-python-command.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test5",
@@ -71,7 +71,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test6-binary-basic.dxt',
+            name: 'test6-binary-basic.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test6",
@@ -83,7 +83,7 @@ async function buildMinimal() {
             }
         },
         {
-            name: 'test7-binary-command.dxt',
+            name: 'test7-binary-command.mcpb',
             manifest: {
                 "manifest_version": "0.3",
                 "name": "Test7",

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -38,8 +38,8 @@ describe('Build System', () => {
             expect(fs.existsSync(distDir)).toBe(true);
         });
         
-        test('build creates DXT file', () => {
-            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.dxt'));
+        test('build creates MCPB file', () => {
+            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
             expect(dxtFiles.length).toBeGreaterThan(0);
             
             const dxtFile = path.join(distDir, dxtFiles[0]);
@@ -49,11 +49,11 @@ describe('Build System', () => {
             expect(stats.size).toBeGreaterThan(0);
         });
         
-        test('DXT file has correct structure', () => {
-            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.dxt'));
+        test('MCPB file has correct structure', () => {
+            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
             const dxtFile = path.join(distDir, dxtFiles[0]);
             
-            // DXT files are archives, we can verify they exist and have content
+            // MCPB files are archives, we can verify they exist and have content
             const stats = fs.statSync(dxtFile);
             expect(stats.isFile()).toBe(true);
             expect(stats.size).toBeGreaterThan(1000); // Should be at least 1KB

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -39,22 +39,22 @@ describe('Build System', () => {
         });
         
         test('build creates MCPB file', () => {
-            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
-            expect(dxtFiles.length).toBeGreaterThan(0);
+            const mcpbFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
+            expect(mcpbFiles.length).toBeGreaterThan(0);
             
-            const dxtFile = path.join(distDir, dxtFiles[0]);
-            expect(fs.existsSync(dxtFile)).toBe(true);
+            const mcpbFile = path.join(distDir, mcpbFiles[0]);
+            expect(fs.existsSync(mcpbFile)).toBe(true);
             
-            const stats = fs.statSync(dxtFile);
+            const stats = fs.statSync(mcpbFile);
             expect(stats.size).toBeGreaterThan(0);
         });
         
         test('MCPB file has correct structure', () => {
-            const dxtFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
-            const dxtFile = path.join(distDir, dxtFiles[0]);
+            const mcpbFiles = fs.readdirSync(distDir).filter(f => f.endsWith('.mcpb'));
+            const mcpbFile = path.join(distDir, mcpbFiles[0]);
             
             // MCPB files are archives, we can verify they exist and have content
-            const stats = fs.statSync(dxtFile);
+            const stats = fs.statSync(mcpbFile);
             expect(stats.isFile()).toBe(true);
             expect(stats.size).toBeGreaterThan(1000); // Should be at least 1KB
         });

--- a/validate-mcpb.js
+++ b/validate-mcpb.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Validate DXT files for OmniFocus Claude Extension
- * Checks the structure and format of generated .dxt files
+ * Validate MCPB files for OmniFocus Claude Extension
+ * Checks the structure and format of generated .mcpb files
  */
 
 const fs = require('fs');
@@ -120,9 +120,9 @@ function validateJsonStructure(filePath) {
 }
 
 /**
- * Validate a DXT file
+ * Validate an MCPB file
  */
-function validateDxtFile(filePath) {
+function validateMcpbFile(filePath) {
     const fileName = path.basename(filePath);
     const fileSize = fs.statSync(filePath).size;
     const sizeKB = (fileSize / 1024).toFixed(2);
@@ -162,7 +162,7 @@ function validateDxtFile(filePath) {
  * Main validation function
  */
 function validateAll() {
-    log.header('🔍 DXT File Validation');
+    log.header('🔍 MCPB File Validation');
     
     if (!fs.existsSync(DIST_DIR)) {
         log.error('dist/ directory not found. Run build first.');
@@ -170,21 +170,21 @@ function validateAll() {
     }
     
     const dxtFiles = fs.readdirSync(DIST_DIR)
-        .filter(f => f.endsWith('.dxt'))
+        .filter(f => f.endsWith('.mcpb'))
         .map(f => path.join(DIST_DIR, f));
     
     if (dxtFiles.length === 0) {
-        log.warning('No .dxt files found in dist/');
+        log.warning('No .mcpb files found in dist/');
         process.exit(1);
     }
     
-    log.info(`Found ${dxtFiles.length} DXT files to validate`);
+    log.info(`Found ${dxtFiles.length} MCPB files to validate`);
     
     let allValid = true;
     const results = [];
     
     for (const dxtFile of dxtFiles) {
-        const isValid = validateDxtFile(dxtFile);
+        const isValid = validateMcpbFile(dxtFile);
         results.push({
             file: path.basename(dxtFile),
             valid: isValid
@@ -207,7 +207,7 @@ function validateAll() {
     }
     
     if (allValid) {
-        log.header('✨ All DXT files are valid!');
+        log.header('✨ All MCPB files are valid!');
     } else {
         log.header('⚠️  Some files have validation issues');
         log.info('Review the issues above and rebuild if necessary');
@@ -221,4 +221,4 @@ if (require.main === module) {
     validateAll();
 }
 
-module.exports = { validateDxtFile, isZipFile, isJsonFile };
+module.exports = { validateMcpbFile, isZipFile, isJsonFile };

--- a/validate-mcpb.js
+++ b/validate-mcpb.js
@@ -169,24 +169,24 @@ function validateAll() {
         process.exit(1);
     }
     
-    const dxtFiles = fs.readdirSync(DIST_DIR)
+    const mcpbFiles = fs.readdirSync(DIST_DIR)
         .filter(f => f.endsWith('.mcpb'))
         .map(f => path.join(DIST_DIR, f));
     
-    if (dxtFiles.length === 0) {
+    if (mcpbFiles.length === 0) {
         log.warning('No .mcpb files found in dist/');
         process.exit(1);
     }
     
-    log.info(`Found ${dxtFiles.length} MCPB files to validate`);
+    log.info(`Found ${mcpbFiles.length} MCPB files to validate`);
     
     let allValid = true;
     const results = [];
     
-    for (const dxtFile of dxtFiles) {
-        const isValid = validateMcpbFile(dxtFile);
+    for (const mcpbFile of mcpbFiles) {
+        const isValid = validateMcpbFile(mcpbFile);
         results.push({
-            file: path.basename(dxtFile),
+            file: path.basename(mcpbFile),
             valid: isValid
         });
         if (!isValid) {


### PR DESCRIPTION
## Summary

Fixes #8

Renames `.dxt` to `.mcpb` throughout the build system, CI pipeline, validation, tests, and documentation to match Anthropic's updated naming convention (September 2025).

## Changes
- Renames `validate-dxt.js` → `validate-mcpb.js` and `build:dxt` → `build:mcpb` npm script (keeping `build:dxt` as a backwards-compatible alias)
- Updates CI workflow artifact names, upload paths, and step labels to `.mcpb`
- Updates README, CONTRIBUTING, CLAUDE.md, and CHANGELOG references
- Bumps version to 2.0.3
- No changes to internal archive format (still ZIP with manifest.json following MCPB v0.3 spec)

## Test plan
- [x] Built extension locally (`npm run build`)
- [x] Validated package (`npm run validate`)
- [x] Manually tested installation in Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)