### PR TITLE
ci: add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.applescript$'
+      - id: end-of-file-fixer
+        exclude: '\.applescript$'
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+        exclude: '\.applescript$'
+
+  - repo: local
+    hooks:
+      - id: node-syntax-check
+        name: Node.js syntax check
+        language: system
+        entry: bash -c 'for f in "$@"; do node -c "$f" || exit 1; done' --
+        types: [javascript]
+        exclude: 'node_modules/'


### PR DESCRIPTION
## Summary

Adds a `.pre-commit-config.yaml` to enforce code quality checks locally before commits reach CI.

## Hooks configured

| Hook | Purpose |
|------|---------|
| `trailing-whitespace` | Remove trailing spaces (excludes `.applescript`) |
| `end-of-file-fixer` | Ensure files end with a newline (excludes `.applescript`) |
| `check-yaml` | Validate YAML syntax (catches broken workflow files) |
| `check-json` | Validate JSON syntax (catches broken manifest/package.json) |
| `check-merge-conflict` | Prevent accidentally committing conflict markers |
| `check-added-large-files` | Block files >500KB from being committed |
| `check-case-conflict` | Prevent filename case conflicts (macOS/Linux portability) |
| `mixed-line-ending` | Enforce LF line endings (excludes `.applescript`) |
| `node-syntax-check` | Run `node -c` on all JS files before commit |

## Notes

- `.applescript` files are excluded from whitespace/line-ending hooks as AppleScript has specific formatting requirements that should not be auto-modified
- All hooks pass cleanly against the current codebase
- Developers need to run `pip install pre-commit && pre-commit install` once after cloning to activate the git hook

## Testing

```bash
pre-commit run --all-files  # All hooks: Passed
```