### PR TITLE
fix: resolve OmniFocus unit constants inside tell block in create_recurring_task

### DIFF
--- a/src/scripts/enhanced/create_recurring_task.applescript
+++ b/src/scripts/enhanced/create_recurring_task.applescript
@@ -85,39 +85,43 @@ end run
 
 on parseRepeatRule(ruleString)
     -- Create a repetition rule record based on the input string
-    set ruleRecord to {unit:week, steps:1}
-    
-    if ruleString is "daily" then
-        set ruleRecord to {unit:day, steps:1}
-    else if ruleString is "weekly" then
+    -- OmniFocus unit constants (day, week, month, year) must be resolved
+    -- inside a tell block so they are in scope.
+    tell application "OmniFocus"
         set ruleRecord to {unit:week, steps:1}
-    else if ruleString is "monthly" then
-        set ruleRecord to {unit:month, steps:1}
-    else if ruleString is "yearly" or ruleString is "annually" then
-        set ruleRecord to {unit:year, steps:1}
-    else if ruleString contains "day" then
-        try
-            set stepCount to word 1 of ruleString as integer
-            set ruleRecord to {unit:day, steps:stepCount}
-        end try
-    else if ruleString contains "week" then
-        try
-            set stepCount to word 1 of ruleString as integer
-            set ruleRecord to {unit:week, steps:stepCount}
-        end try
-    else if ruleString contains "month" then
-        try
-            set stepCount to word 1 of ruleString as integer
-            set ruleRecord to {unit:month, steps:stepCount}
-        end try
-    else if ruleString contains "year" then
-        try
-            set stepCount to word 1 of ruleString as integer
-            set ruleRecord to {unit:year, steps:stepCount}
-        end try
-    end if
-    
-    return ruleRecord
+        
+        if ruleString is "daily" then
+            set ruleRecord to {unit:day, steps:1}
+        else if ruleString is "weekly" then
+            set ruleRecord to {unit:week, steps:1}
+        else if ruleString is "monthly" then
+            set ruleRecord to {unit:month, steps:1}
+        else if ruleString is "yearly" or ruleString is "annually" then
+            set ruleRecord to {unit:year, steps:1}
+        else if ruleString contains "day" then
+            try
+                set stepCount to word 1 of ruleString as integer
+                set ruleRecord to {unit:day, steps:stepCount}
+            end try
+        else if ruleString contains "week" then
+            try
+                set stepCount to word 1 of ruleString as integer
+                set ruleRecord to {unit:week, steps:stepCount}
+            end try
+        else if ruleString contains "month" then
+            try
+                set stepCount to word 1 of ruleString as integer
+                set ruleRecord to {unit:month, steps:stepCount}
+            end try
+        else if ruleString contains "year" then
+            try
+                set stepCount to word 1 of ruleString as integer
+                set ruleRecord to {unit:year, steps:stepCount}
+            end try
+        end if
+        
+        return ruleRecord
+    end tell
 end parseRepeatRule
 
 on parseDate(dateString)


### PR DESCRIPTION
## Bug

`create_recurring_task` creates the task successfully but then fails with:

```
⚠️ Created task but couldn't set repeat: The variable week is not defined.
```

This happens for any `repeat_rule` value (`weekly`, `monthly`, `daily`, etc.).

## Root Cause

The `parseRepeatRule` handler uses OmniFocus-specific enumeration constants (`day`, `week`, `month`, `year`) to build the repetition rule record:

```applescript
set ruleRecord to {unit:week, steps:1}
```

AppleScript only resolves application-specific enumerations when the code executes inside a `tell application "OmniFocus"` block. Because `parseRepeatRule` is a top-level handler defined outside any `tell` block, these identifiers are treated as undefined variables at runtime.

## Fix

Wrap the `parseRepeatRule` handler body in `tell application "OmniFocus" ... end tell` so the unit constants are resolved correctly.

## Testing

```bash
osascript src/scripts/enhanced/create_recurring_task.applescript "Test task" "weekly" "" ""
osascript src/scripts/enhanced/create_recurring_task.applescript "Test task" "monthly" "" ""
osascript src/scripts/enhanced/create_recurring_task.applescript "Test task" "2 weeks" "" ""
```
All should now report the repeat rule instead of the variable-not-defined error.