### PR TITLE
Add tag hierarchy support with indentation to list_tags script

### DIFF
--- a/src/scripts/enhanced/list_tags.applescript
+++ b/src/scripts/enhanced/list_tags.applescript
@@ -1,5 +1,5 @@
 on run argv
-    -- List all tags in OmniFocus
+    -- List all tags in OmniFocus with hierarchy (indentation shows parent/child relationships)
     -- Usage: list_tags.applescript [include_counts]
     -- Pass "true" as first argument to include per-tag task counts (slower on large databases)
 
@@ -10,57 +10,93 @@ on run argv
 
     tell application "OmniFocus"
         tell default document
-            set allTags to every tag
-            if (count of allTags) = 0 then
+            set topTags to every tag
+            if (count of topTags) = 0 then
                 return "🏷️ No tags found in OmniFocus."
             end if
 
-            set resultText to "🏷️ Tags (" & (count of allTags) & "):" & return
+            set flatTags to every flattened tag
+            set resultText to "🏷️ Tags (" & (count of flatTags) & "):" & return
 
             if includeCounts then
-                -- Build a tag→count map in a single pass over tasks
+                -- Build a tag id→count map in a single pass over tasks
                 set tagCountRecord to {}
                 set activeTasks to every flattened task whose completed is false
                 repeat with aTask in activeTasks
                     set taskTags to tags of aTask
                     repeat with aTag in taskTags
-                        set tName to name of aTag
+                        set tID to id of aTag
                         set found to false
                         repeat with entry in tagCountRecord
-                            if tagLabel of entry is tName then
+                            if tagID of entry is tID then
                                 set tagCount of entry to (tagCount of entry) + 1
                                 set found to true
                                 exit repeat
                             end if
                         end repeat
                         if not found then
-                            set end of tagCountRecord to {tagLabel:tName, tagCount:1}
+                            set end of tagCountRecord to {tagID:tID, tagCount:1}
                         end if
                     end repeat
                 end repeat
 
-                repeat with aTag in allTags
-                    set tagName to name of aTag
-                    set taggedCount to 0
-                    repeat with entry in tagCountRecord
-                        if tagLabel of entry is tagName then
-                            set taggedCount to tagCount of entry
-                            exit repeat
-                        end if
-                    end repeat
-                    set resultText to resultText & "• " & tagName
-                    if taggedCount > 0 then
-                        set resultText to resultText & " (" & taggedCount & " tasks)"
-                    end if
-                    set resultText to resultText & return
-                end repeat
+                set resultText to resultText & my formatTagsWithCounts(topTags, 0, tagCountRecord)
             else
-                repeat with aTag in allTags
-                    set resultText to resultText & "• " & name of aTag & return
-                end repeat
+                set resultText to resultText & my formatTags(topTags, 0)
             end if
 
             return resultText
         end tell
     end tell
 end run
+
+-- Recursively format tags with indentation (no counts)
+on formatTags(tagList, depth)
+    set output to ""
+    tell application "OmniFocus"
+        repeat with aTag in tagList
+            set indent to ""
+            repeat depth times
+                set indent to indent & "  "
+            end repeat
+            set output to output & indent & "• " & name of aTag & return
+            set childTags to every tag of aTag
+            if (count of childTags) > 0 then
+                set output to output & my formatTags(childTags, depth + 1)
+            end if
+        end repeat
+    end tell
+    return output
+end formatTags
+
+-- Recursively format tags with indentation and task counts
+on formatTagsWithCounts(tagList, depth, tagCountRecord)
+    set output to ""
+    tell application "OmniFocus"
+        repeat with aTag in tagList
+            set indent to ""
+            repeat depth times
+                set indent to indent & "  "
+            end repeat
+            set tagName to name of aTag
+            set tID to id of aTag
+            set taggedCount to 0
+            repeat with entry in tagCountRecord
+                if tagID of entry is tID then
+                    set taggedCount to tagCount of entry
+                    exit repeat
+                end if
+            end repeat
+            set output to output & indent & "• " & tagName
+            if taggedCount > 0 then
+                set output to output & " (" & taggedCount & " tasks)"
+            end if
+            set output to output & return
+            set childTags to every tag of aTag
+            if (count of childTags) > 0 then
+                set output to output & my formatTagsWithCounts(childTags, depth + 1, tagCountRecord)
+            end if
+        end repeat
+    end tell
+    return output
+end formatTagsWithCounts

--- a/tests/applescript.test.js
+++ b/tests/applescript.test.js
@@ -234,6 +234,46 @@ describe('AppleScript Integration', () => {
         });
     });
 
+    describe('list_tags Hierarchy Support', () => {
+        const scriptPath = path.join(enhancedScriptsDir, 'list_tags.applescript');
+
+        test('uses recursive formatTags handler for hierarchical output', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            expect(content).toMatch(/on formatTags\(tagList, depth\)/);
+            expect(content).toMatch(/my formatTags\(childTags, depth \+ 1\)/);
+        });
+
+        test('uses recursive formatTagsWithCounts handler for hierarchical output with counts', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            expect(content).toMatch(/on formatTagsWithCounts\(tagList, depth, tagCountRecord\)/);
+            expect(content).toMatch(/my formatTagsWithCounts\(childTags, depth \+ 1, tagCountRecord\)/);
+        });
+
+        test('indents child tags based on depth', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            // Both handlers should build indent strings by repeating spaces per depth level
+            expect(content).toMatch(/repeat depth times/);
+            expect(content).toMatch(/set indent to indent & "  "/);
+        });
+
+        test('fetches child tags for recursion', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            expect(content).toMatch(/set childTags to every tag of aTag/);
+        });
+
+        test('uses every flattened tag for total count', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            expect(content).toMatch(/set flatTags to every flattened tag/);
+            expect(content).toMatch(/count of flatTags/);
+        });
+
+        test('uses tag id instead of name for count map', () => {
+            const content = fs.readFileSync(scriptPath, 'utf8');
+            expect(content).toMatch(/set tID to id of aTag/);
+            expect(content).toMatch(/tagID:tID/);
+        });
+    });
+
     describe('Tool-Script Coverage', () => {
         const serverPath = path.join(__dirname, '..', 'src', 'server', 'index.js');
 


### PR DESCRIPTION
## Summary
Enhanced the `list_tags.applescript` script to display OmniFocus tags in a hierarchical format with indentation, showing parent-child relationships between tags.

Fixes #20 

## Key Changes
- **Hierarchical display**: Tags are now displayed with indentation that reflects their parent-child relationships (2 spaces per level)
- **Refactored logic into helper functions**: 
  - `formatTags()`: Recursively formats tags without counts
  - `formatTagsWithCounts()`: Recursively formats tags with task counts
- **Improved tag counting**: Changed from using tag names to tag IDs for counting, which is more reliable and handles tags with identical names
- **Updated documentation**: Modified the script header comment to clarify that the output now shows hierarchy with indentation

## Implementation Details
- Both helper functions use recursion to traverse the tag hierarchy and apply appropriate indentation based on depth
- Tag counting now uses `id of aTag` instead of `name of aTag` to create a more robust tag→count mapping
- The script maintains backward compatibility with the `include_counts` parameter
- Child tags are retrieved using `every tag of aTag` to access the parent-child relationships

https://claude.ai/code/session_01K1BZsB6b597p6x67Tq2p8N